### PR TITLE
Remove duplicate phase shift

### DIFF
--- a/phazap/phazap.py
+++ b/phazap/phazap.py
@@ -202,14 +202,19 @@ def _phazap(event1_postprocessed_phase, event2_postprocessed_phase):
     vol_phases_12, dist_12, neff_12 = phazap_one_ordering(event1_postprocessed_phase, event2_postprocessed_phase)
     vol_phases_21, dist_21, neff_21 = phazap_one_ordering(event2_postprocessed_phase, event1_postprocessed_phase)
 
-    dist_21_swap = np.array([dist_21[0],dist_21[3],dist_21[4],dist_21[1],dist_21[2]])
+    """
+    dist_12 is [0, +pi/2, +pi, -pi/2]
+    this should corresponds to dist_21 of
+    [0, -pi/2, +pi, +pi/2]
+    """
+    dist_21_swap = np.array([dist_21[0],dist_21[3],dist_21[2],dist_21[1]])
     D_J_n = np.maximum(dist_12,dist_21_swap)
     D_J = np.min(D_J_n)
     
     vol_J = vol_phases_12 + vol_phases_21
 
     #Phase shift
-    phase_shifts = np.array([0,1,2,-1,-2])*np.pi/2
+    phase_shifts = np.array([0,1,2,-1])*np.pi/2
     phase_shift = phase_shifts[np.argmin(D_J_n)]
 
     #Compute p-value

--- a/phazap/plot_utils.py
+++ b/phazap/plot_utils.py
@@ -46,7 +46,7 @@ def phazap_plot(event1_postprocessed_phase, event2_postprocessed_phase, output_d
 
     dist = dist_all
 
-    phase_shifts = np.array([0,1,2,-1,-2])*np.pi/2
+    phase_shifts = np.array([0,1,2,-1])*np.pi/2
     phase_shift = phase_shifts[np.argmin(dist)]*np.hstack((np.ones(nphases),np.zeros(length-nphases)))
 
     #Event 2 is shifted by the phase shift that minimizes the distance

--- a/phazap/plot_utils.py
+++ b/phazap/plot_utils.py
@@ -56,15 +56,17 @@ def phazap_plot(event1_postprocessed_phase, event2_postprocessed_phase, output_d
     parameters_1_wrap, parameters_2_wrap = utils.wrap_phases(parameters_1,parameters_2_shifted,nphases)
 
     #labels
-    labels = [r'\phi_\mathrm{H}',
-              r'\phi_\mathrm{L}',
-              r'\phi_\mathrm{V}',
-              r'\Delta\phi_f',
-             r'\tau_\mathrm{HL}',
-                 r'\tau_\mathrm{HV}']
+    labels = [
+        r'\phi_\mathrm{H}',
+        r'\phi_\mathrm{L}',
+        r'\phi_\mathrm{V}',
+        r'\Delta\phi_f',
+        r'\tau_\mathrm{HL}',
+        r'\tau_\mathrm{HV}',
+    ]
 
     label_1 = event_name_1
-    best_phase_shift = utils.format_pretty_phase_shift(phase_shifts[np.argmin(dist)]).replace('0', '0pi').replace('pi', '\pi')
+    best_phase_shift = utils.format_pretty_phase_shift(phase_shifts[np.argmin(dist)]).replace('0', '0π').replace('π', '\pi').replace('±', '\pm')
     label_2 = fr"{event_name_2} (shifted by ${best_phase_shift}$)"
 
     color_1 = 'blue'
@@ -90,7 +92,7 @@ def phazap_plot(event1_postprocessed_phase, event2_postprocessed_phase, output_d
                     colors = [color_1, color_2],
                    line_args = [{'color':color_1},{'color':color_2}])
 
-    plt.suptitle(r'Minimum distance =%s' % np.round(np.min(dist),2)+r', volume = %s' % np.round(np.min(vol_phases_1),2), va='bottom')
+    plt.suptitle(r'Minimum distance = %s' % np.round(np.min(dist),2)+r', volume = %s' % np.round(np.min(vol_phases_1),2), va='bottom')
 
     if output_filename is None:
         output_filename = _default_plot_filename_str.format(

--- a/phazap/tension_utils.py
+++ b/phazap/tension_utils.py
@@ -47,7 +47,7 @@ def distance_phases(parameters_1,parameters_2,nphases):
 
 def distance_phases_with_shift(parameters_1,parameters_2,nphases):
     #Add possible lensing phase shifts
-    phase_shifts = np.array([0,1,2,-1,-2])*np.pi/2
+    phase_shifts = np.array([0,1,2,-1])*np.pi/2
     distances = 0.*phase_shifts
     
     #Loop around phase shifts
@@ -71,7 +71,7 @@ def distance_only_phases(phases_1,phases_2):
 
 def distance_only_phases_with_shift(parameters_1,parameters_2):
     #Add possible lensing phase shift
-    phase_shifts = np.array([0,1,2,-1,-2])*np.pi/2
+    phase_shifts = np.array([0,1,2,-1])*np.pi/2
     distances = 0.*phase_shifts
     
     length = np.shape(parameters_1)[1]

--- a/phazap/utils.py
+++ b/phazap/utils.py
@@ -2,13 +2,14 @@ import numpy as np
 
 def format_pretty_phase_shift(phase_shift):
     # phase_shift can only be multiple of pi/2
+    # NOTE In newer versions of phazap we do not explicitly compute -pi phase shift
     prefactor = int(phase_shift/np.pi * 2) # This should be an integer
     conversion_chart = {
         0: "0",
-        1: "+pi/2",
-        2: "+pi",
-        -1: "-pi/2",
-        -2: "-pi",
+        1: "+π/2",
+        2: "±π",
+        -1: "-π/2",
+        -2: "-π",
     }
     return conversion_chart[prefactor]
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-verstr = "0.2.0"
+verstr = "0.3.0"
 
 setuptools.setup(
     name="phazap",


### PR DESCRIPTION
Since a phase shift of +pi is degenerate with a phase shift of -pi, in this PR we explicitly remove the -pi phase shift calculation to improve the performance with no loss of information